### PR TITLE
Display the ellipsis outside the display area

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Cocos Creator",
   "main": "main.js",
   "main-menu": {
-    "i18n:MAIN_MENU.package.title/i18n/open": {
+    "i18n:MAIN_MENU.package.title/i18n": {
       "message": "i18n:open"
     }
   },
@@ -24,7 +24,9 @@
     "type": "dockable",
     "title": "i18n",
     "width": 400,
-    "height": 300
+    "height": 300,
+    "min-width": 300,
+    "min-height": 300
   },
   "profiles": { 
     "project": {

--- a/panel/style/home.less
+++ b/panel/style/home.less
@@ -71,9 +71,18 @@
                 }
 
                 .name {
-                    width: 110px;
+                    width: 90px;
                     overflow: hidden;
                     text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+
+                .path {
+                    flex: 1;
+                    width: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                 }
             }
         }


### PR DESCRIPTION
1. 菜单栏修改。
    之前 i18n 项目下只有一个 open，点击 i18n 直接打开就行了。open 这个层级没有必要
2. 显示优化。
    语言名字和地址如果超出显示区域，显示省略号